### PR TITLE
canonicalRequest: Allow "UNSIGNED-PAYLOAD"

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ let
 
   finalUrl  = url & "?" & request.split("\n")[2] & "&X-Amz-Signature=" & signature
 
-assert finalUrl == "https://my-bucket.s3-eu-west-1.amazonaws.com/2021/my-image.jpg?Action=GetObject&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAA0BPAG50Q8KFTR7F%2F20210330%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20210330T032054Z&X-Amz-Expires=60&X-Amz-SignedHeaders=host&X-Amz-Signature=c240c603fb213c22283cda425a3e6bda3d142968ebb05a04b679767ab3936513"
+assert finalUrl == "https://my-bucket.s3-eu-west-1.amazonaws.com/2021/my-image.jpg?Action=GetObject&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAQ0BPAG50Q8KFTR7F%2F20210330%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20210330T032054Z&X-Amz-Expires=60&X-Amz-SignedHeaders=host&X-Amz-Signature=e4506eac1665d53c658a3229118067a3f01bc00ee8ab3c8f9708b789ca5c9673"
 ```
 
 ## Documentation

--- a/sigv4.nim
+++ b/sigv4.nim
@@ -271,7 +271,7 @@ proc canonicalRequest*(meth: HttpMethod;
   result.add query.encodedQuery() & "\n"
   result.add heads.canonical & "\n"
   result.add heads.signed & "\n"
-  result.add hash(payload, digest)
+  result.add (if payload == "UNSIGNED-PAYLOAD": payload else: hash(payload, digest))
 
 template assertDateLooksValid(d: string; format: DateFormat) =
   when not defined(release):

--- a/sigv4.nim
+++ b/sigv4.nim
@@ -345,3 +345,5 @@ proc calculateSignature*(secret: string; date: string; region: string;
     var key = deriveKey(SHA512Digest, secret, date, region, service)
     key.add tosign
     result = key.toLowerHex
+  of UnsignedPayload:
+    discard

--- a/sigv4.nim
+++ b/sigv4.nim
@@ -273,7 +273,7 @@ proc canonicalRequest*(meth: HttpMethod;
   result.add query.encodedQuery() & "\n"
   result.add heads.canonical & "\n"
   result.add heads.signed & "\n"
-  result.add (if payload == "UNSIGNED-PAYLOAD": payload else: hash(payload, digest))
+  result.add hash(payload, digest)
 
 template assertDateLooksValid(d: string; format: DateFormat) =
   when not defined(release):

--- a/sigv4.nim
+++ b/sigv4.nim
@@ -97,6 +97,7 @@ type
   SigningAlgo* = enum
     SHA256 = "AWS4-HMAC-SHA256"
     SHA512 = "AWS4-HMAC-SHA512"
+    UnsignedPayload = "UNSIGNED-PAYLOAD"
   DigestTypes = MDigest256 or MDigest512
   EncodedHeaders* = tuple[signed: string; canonical: string]
   KeyValue = tuple[key: string; val: string]
@@ -252,6 +253,7 @@ proc hash*(payload: string; digest: SigningAlgo): string =
   case digest
   of SHA256: result = computeSHA256(payload).toLowerHex
   of SHA512: result = computeSHA512(payload).toLowerHex
+  of UnsignedPayload: result = $UnsignedPayload
 
 proc canonicalRequest*(meth: HttpMethod;
                       url: string;


### PR DESCRIPTION
In the `canonicalRequest()` the payload is always hashed. But when using `AWS S3 GetObject` we need to provide the payload as is: "UNSIGNED-PAYLOAD". Otherwise our signing does not match.

https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
```
You don't include a payload hash in the Canonical Request, because when you create a presigned URL, you don't know the payload content because the URL is used to upload an arbitrary payload. Instead, you use a constant string UNSIGNED-PAYLOAD.
```